### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,13 @@ processResources
     }
 }
 
+task deobfJar(type: Jar) {
+    from sourceSets.main.output
+    classifier = 'dev'
+}
+
+build.dependsOn deobfJar
+
 idea { 
 	module { 
 		inheritOutputDirs = true 


### PR DESCRIPTION
For automatically building a dev jar (deobfuscated compiled). For those mod devs that want the full mod to be available partially readable and fully usable within minecraft in the dev env.
