### PR TITLE
Save config before requireOreSpawn is checked

### DIFF
--- a/src/main/java/cyano/basemetals/BaseMetals.java
+++ b/src/main/java/cyano/basemetals/BaseMetals.java
@@ -149,6 +149,8 @@ public class BaseMetals
 			}
 		}
 
+		config.save();
+
 		if(requireOreSpawn) {
 			if(!net.minecraftforge.fml.common.Loader.isModLoaded("orespawn")){
 				HashSet<ArtifactVersion> orespawnMod = new HashSet<>();
@@ -166,8 +168,6 @@ public class BaseMetals
 				}
 			}
 		}
-
-		config.save();
 
 		cyano.basemetals.init.Fluids.init();
 		cyano.basemetals.init.Materials.init();


### PR DESCRIPTION
Allows for actually removing Ore Spawn dependency

Otherwise the config wouldn't exist when the configuration was created for the first time, preventing properly disabling the Ore Spawn requirement.
